### PR TITLE
Fix dataflow editor dest component enabled state bug

### DIFF
--- a/src/DataFlowsEditor.tsx
+++ b/src/DataFlowsEditor.tsx
@@ -50,7 +50,7 @@ function NewDataFlowForm(props: {
           <Grid item xs={6}>
             <Autocomplete
               onChange={(event, value) => { setDestComponent(value) }}
-              disabled={sourceComponent === undefined}
+              disabled={sourceComponent === null}
               value={destComponent}
               disablePortal
               options={props.componentChoices


### PR DESCRIPTION
On the data flow editor new flow form, the dest component autocomplete
should not be enabled unless a source component has already
been selected. This fixes the bug by correcting a boolean expression.