### PR TITLE
Data flow editor now auto-adds on selection of destination component

### DIFF
--- a/src/DataFlowsEditor.tsx
+++ b/src/DataFlowsEditor.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
-import { Autocomplete, Button, IconButton, List, ListItem, ListItemText} from '@mui/material';
+import { Autocomplete, IconButton, List, ListItem, ListItemText} from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 
 interface DataFlowEditorProps {
@@ -21,26 +21,27 @@ function NewDataFlowForm(props: {
   handleSubmit: (sourceComponent: string, destComponent: string) => void 
 }) {
   const [sourceComponent, setSourceComponent] = React.useState<string | null>(null)
-  const [destComponent, setDestComponent] = React.useState<string | null>(null)
 
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleDestComponentChange = (destComponent: string | null) => {
     if (sourceComponent !== null && destComponent !== null) {
       props.handleSubmit(sourceComponent, destComponent)
-      setSourceComponent(null)
-      setDestComponent(null)
+      setSourceComponent(null);
+
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
     }
-    event.preventDefault()
   }
 
   const dataFlowExists = (sourceComponent: string, destComponent: string) => props.dataFlows.get(sourceComponent)?.has(destComponent) ||
     props.dataFlows.get(destComponent)?.has(sourceComponent)
 
   return <React.Fragment>
-    <form onSubmit={handleSubmit}>
+    <form>
         <Grid container spacing={2}>
           <Grid item xs={6}>
             <Autocomplete
-              onChange={(event, value) => { setSourceComponent(value) }}
+              onChange={(_, value) => { setSourceComponent(value) }}
               value={sourceComponent}
               disablePortal
               options={props.componentChoices}
@@ -49,18 +50,15 @@ function NewDataFlowForm(props: {
           </Grid>
           <Grid item xs={6}>
             <Autocomplete
-              onChange={(event, value) => { setDestComponent(value) }}
+              onChange={(_, value) => { handleDestComponentChange(value) }}
               disabled={sourceComponent === null}
-              value={destComponent}
+              value={null}
               disablePortal
               options={props.componentChoices
                 .filter(choice => choice !== sourceComponent)
                 .filter(choice => sourceComponent == null || !dataFlowExists(sourceComponent, choice))}
               renderInput={(params) => <TextField {...params} label="Destination Component" required />}
             />
-          </Grid>
-          <Grid item xs={6}>
-            <Button variant="contained" type="submit">Add Data Flow</Button>
           </Grid>
         </Grid>
       </form>


### PR DESCRIPTION
Having a separate add button doesn't really add
value for the data flow editor - since selecting a
destination component for a data flow is the last
bit of information we need, we can trigger the
add action on selection of the destination component to save users
the extra click.

This does make it a little harder if users accidentally
add a dataflow they didn't intend to add (since
there is no more separate form-submit event);
however, since it's only a few clicks to fix such an
error, and we assume such errors should be
uncommon, this change biases toward making intential
adds slightly faster at the expense of making
correction of unintentional adds slightly slower.