### PR TITLE
Rename Checkout component to DiscussionWizard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import Checkout from './Checkout';
+import DiscussionWizard from './DiscussionWizard';
 
 export default function App() {
   return (
-    <Checkout /> 
+    <DiscussionWizard /> 
   );
 }

--- a/src/DiscussionWizard.tsx
+++ b/src/DiscussionWizard.tsx
@@ -37,7 +37,7 @@ function Copyright() {
 
 const steps = ['Intro', 'Components', 'Data Flows', 'Discussion Guide'];
 
-export default function Checkout() {
+export default function DiscussionWizard() {
   const [activeStep, setActiveStep] = React.useState(0);
   const [components, setComponents] = React.useState<string[]>([]);
   const [componentTraitsMap, setComponentTraitsMap] = React.useState(new Map<string, Trait[]>())


### PR DESCRIPTION
This removes a lingering element of the Material UI checkout template,
making it easier to understand what this component actually does (walks
a user through generating a discussion guide).