### PR TITLE
Simplify trait system to only support 'out of scope' for now

### DIFF
--- a/src/ComponentsEditor.tsx
+++ b/src/ComponentsEditor.tsx
@@ -5,11 +5,10 @@ import * as React from 'react';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
-import { Autocomplete, Box, Button, IconButton, List, ListItem, ListItemText, Paper, Tooltip} from '@mui/material';
+import { Button, Checkbox, FormControlLabel, IconButton, List, ListItem, ListItemText, Paper} from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
-import HelpIcon from '@mui/icons-material/Help';
 import { useTheme } from '@mui/material/styles';
-import { AllTraits, Trait } from './ComponentTraits';
+import { Trait, Traits } from './ComponentTraits';
 
 interface ComponentsEditorProps {
   components: string[],
@@ -17,6 +16,9 @@ interface ComponentsEditorProps {
   addComponent: (component: string) => void,
   removeComponent: (component: string) => void
   setComponentTraits: (component: string, selectedTraits: Trait[]) => void
+  addComponentTrait: (component: string, trait: Trait) => void
+  removeComponentTrait: (component: string, trait: Trait) => void
+  componentHasTrait: (component: string, trait: Trait) => boolean
 }
 
 function NewComponentForm(props: { handleSubmit: (newComponentName: string) => void }) {
@@ -74,52 +76,30 @@ export default function ComponentsEditor(props: ComponentsEditorProps) {
               <Grid container>
                 <Grid item xs={12}>
                   <ListItemText
-                    primary={component}
+                    primary={<Typography variant="h6">{component}</Typography>}
                   />
                 </Grid>
-                <Grid item xs={7}>
+                <Grid item xs={10}>
                   <Grid container direction="row" alignItems="center">
-                    <Grid item xs={11}>
-                      <Autocomplete
-                        multiple
-                        id="tags-standard"
-                        options={AllTraits}
-                        value={props.componentTraitsMap.get(component) ?? []}
-                        getOptionLabel={(option) => option.name}
-                        renderInput={(params) => (
-                            <TextField
-                              {...params}
-                              variant="standard"
-                              label="Traits"
-                              placeholder="Traits"
-                            />
-                        )}
-                        renderOption={(props, option) => (
-                          <li {...props}>
-                            <Box
-                              sx={{
-                                flexGrow: 1,
-                                '& span': {
-                                  color:
-                                    theme.palette.mode === 'light' ? '#586069' : '#8b949e',
-                                },
-                              }}
-                            >
-                              {option.name}
-                              <br />
-                              <span>{option.description}</span>
-                            </Box>
-                          </li>
-                        )}
-                        onChange={(_event, selectedTraits) => { props.setComponentTraits(component, selectedTraits)}}
-                      />
-                    </Grid>
-                    <Grid item>
-                      <Box sx={{marginTop: '1em'}}>
-                        <Tooltip title="Add relevant traits to improve the suggestions provided in the discussion guide.">
-                          <HelpIcon />
-                        </Tooltip>
-                      </Box>
+                    <Grid item xs={12}>
+                      <FormControlLabel 
+                        control={
+                          <Checkbox 
+                            onChange={(_event, checked) => { if (checked) { props.addComponentTrait(component, Traits.OutOfScope)} else { props.removeComponentTrait(component, Traits.OutOfScope) }}}
+                            checked={props.componentHasTrait(component, Traits.OutOfScope)}
+                          />
+                        } 
+                        label={
+                          <div>
+                            <Typography variant="subtitle2">
+                              Out of Scope
+                            </Typography>
+                            <Typography variant="caption">
+                              Our system interacts with this component, but we are not responsible for securing it.
+                            </Typography>
+                          </div>
+                        } 
+                    />
                     </Grid>
                   </Grid>
                 </Grid>

--- a/src/ComponentsEditor.tsx
+++ b/src/ComponentsEditor.tsx
@@ -7,7 +7,6 @@ import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
 import { Button, Checkbox, FormControlLabel, IconButton, List, ListItem, ListItemText, Paper} from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { useTheme } from '@mui/material/styles';
 import { Trait, Traits } from './ComponentTraits';
 
 interface ComponentsEditorProps {
@@ -49,7 +48,6 @@ function NewComponentForm(props: { handleSubmit: (newComponentName: string) => v
 }
 
 export default function ComponentsEditor(props: ComponentsEditorProps) {
-  const theme = useTheme()
 
   return (
     <React.Fragment>

--- a/src/DiscussionWizard.tsx
+++ b/src/DiscussionWizard.tsx
@@ -63,6 +63,43 @@ export default function DiscussionWizard() {
     setComponentTraitsMap(updatedComponentTraitsMap)
   }
 
+  const addComponentTrait = (component: string, trait: Trait) => {
+    var updatedComponentTraitsMap = new Map(Array.from(componentTraitsMap, ([key, value]: [string, Trait[]]) => [key, Array.from(value)]))
+
+    var componentTraits = updatedComponentTraitsMap.get(component)
+    if (componentTraits === undefined) {
+      throw new Error("Expected component to exist")
+    }
+
+    if (!componentTraits.some(it => it.name === trait.name)) {
+      componentTraits.push(trait)
+    }
+
+    setComponentTraitsMap(updatedComponentTraitsMap)
+  }
+
+  const removeComponentTrait = (component: string, trait: Trait) => {
+    var updatedComponentTraitsMap = new Map(Array.from(componentTraitsMap, ([key, value]: [string, Trait[]]) => [key, Array.from(value)]))
+
+    var componentTraits = updatedComponentTraitsMap.get(component)
+    if (componentTraits === undefined) {
+      throw new Error("Expected component to exist")
+    }
+
+    componentTraits = componentTraits.filter(it => it.name !== trait.name)
+    updatedComponentTraitsMap.set(component, componentTraits)
+    setComponentTraitsMap(updatedComponentTraitsMap)
+  }
+
+  const componentHasTrait = (component: string, trait: Trait) => {
+    var componentTraits = componentTraitsMap.get(component)
+    if (componentTraits === undefined) {
+      throw new Error("Expected component to exist")
+    }
+
+    return componentTraits.some(it => it.name === trait.name)
+  }
+
   const addComponent = (component: string) => {
     var updatedComponents = new Set(components)
     updatedComponents.add(component)
@@ -147,7 +184,16 @@ export default function DiscussionWizard() {
                 {
                   [
                     <Intro />,
-                    <ComponentsEditor components={components} componentTraitsMap={componentTraitsMap} addComponent={addComponent} removeComponent={removeComponent} setComponentTraits={setComponentTraits} />,
+                    <ComponentsEditor 
+                      components={components} 
+                      componentTraitsMap={componentTraitsMap} 
+                      addComponent={addComponent} 
+                      removeComponent={removeComponent} 
+                      setComponentTraits={setComponentTraits}
+                      addComponentTrait={addComponentTrait}
+                      removeComponentTrait={removeComponentTrait}
+                      componentHasTrait={componentHasTrait}
+                    />,
                     <DataFlowsEditor 
                       components={components}
                       dataFlows={dataFlows}


### PR DESCRIPTION
The existing trait system added a farily significant amount of complexity to the component editor page - this seems like it could deter potential users before they have had a chance to try generating a discussion guide.

To address that, this change reduces complexity by removing support for any traits other than 'out of scope' and by replacing the autocomplete fields on the component editor page with checkboxes.

If/when I come back to experimenting with more intelligent suggestion generation for the discussion guide, it seems like a better strategy would be to add any kind of information gathering / expert system onto the discussion guide itself, such that users only need to engage with the additional complexity/questions if they are interested in getting suggestions more tailored to their situation.